### PR TITLE
Morecrew missing

### DIFF
--- a/client/morecrew.json
+++ b/client/morecrew.json
@@ -20,5 +20,7 @@
   {"name":"Polywater Yar", "wiki":"/wiki/Polywater_Yar", "stars":5},
   {"name":"Admiral Ross", "wiki":"/wiki/Admiral_Ross", "stars":4},
   {"name":"Reverend Phlox", "wiki":"/wiki/Reverend_Phlox", "stars":5},
-  {"name":"Yelgrun", "wiki":"/wiki/Yelgrun", "stars":4}
+  {"name":"Yelgrun", "wiki":"/wiki/Yelgrun", "stars":4},
+  {"name":"Amelia Earhart", "wiki":"/wiki/Amelia_Earhart", "stars":5},
+  {"name":"Gary Seven", "wiki":"wiki/Gary_Seven", "stars":5}
 ]

--- a/client/morecrew.json
+++ b/client/morecrew.json
@@ -22,5 +22,5 @@
   {"name":"Reverend Phlox", "wiki":"/wiki/Reverend_Phlox", "stars":5},
   {"name":"Yelgrun", "wiki":"/wiki/Yelgrun", "stars":4},
   {"name":"Amelia Earhart", "wiki":"/wiki/Amelia_Earhart", "stars":5},
-  {"name":"Gary Seven", "wiki":"wiki/Gary_Seven", "stars":5}
+  {"name":"Gary Seven", "wiki":"/wiki/Gary_Seven", "stars":5}
 ]


### PR DESCRIPTION
Found two missing crew from portal packs.

This takes crew count to 588.
`jq '.crewentries | length' wikidb.json`
