### PR TITLE
Dependencies fix

### DIFF
--- a/lib/modules/clapp-discord/index.js
+++ b/lib/modules/clapp-discord/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const Clapp = require('clapp')
-  , Table = require('cli-table2')
+  , Table = require('cli-table3')
   , str   = require('./str-en.js');
 
 class App extends Clapp.App {


### PR DESCRIPTION
Updated clapp-discord dependencies to cli-table3.

Found this while trying to build a fresh docker container for gotbot.