### PR TITLE
Update morecrew.json

### DIFF
--- a/client/morecrew.json
+++ b/client/morecrew.json
@@ -24,6 +24,6 @@
   {"name":"Amelia Earhart", "wiki":"/wiki/Amelia_Earhart", "stars":5},
   {"name":"Gary Seven", "wiki":"/wiki/Gary_Seven", "stars":5},
   {"name":"Changeling Martok", "wiki":"/wiki/Changeling_Martok", "stars":5},
-  {"name":"Ikat'Ika", "wiki":"/wiki/Ikat%27ika", "stars":4},
+  {"name":"Ikat'Ika", "wiki":"/wiki/Ikat'ika", "stars":4},
   {"name":"Fleet Commander Martok", "wiki":"/wiki/Fleet_Commander_Martok", "stars":2}
 ]


### PR DESCRIPTION
Replaced "%27" with an apostrophe in the wiki url for Ikat'Ika in an attempt to fix an apparent problem.