### PR TITLE
Fix nonstandard characters in crew names

### DIFF
--- a/gotcron
+++ b/gotcron
@@ -39,6 +39,26 @@ download_wiki() {
     grep -A 3 FINISHED data/logs/ssr.log
 }
 
+fix_ssr_crew() {
+    echo "Fixing SSR crew mismatches"
+    pushd data/ssr.izausomecreations.com/crew
+
+    # Handle unicode apostrophe U+2019
+    zhiodo=$'Zhian\xe2\x80\x99tara Odo.json'
+
+    # SSR has these files, but they're not updated
+    rm Emergency\ Medical\ Holoprogram\ Mk.1.json
+    rm \!Q\!Dark\ Ages\!Q\!\ McCoy.json
+    rm "$zhiodo"
+
+    # These are the updated ones!
+    ln -s Emergency\ Medical\ Holoprogram\ Mk.\ 1.json Emergency\ Medical\ Holoprogram\ Mk.1.json
+    ln -s \'\'Dark\ Ages\'\'\ McCoy.json \!Q\!Dark\ Ages\!Q\!\ McCoy.json
+    ln -s Zhian\'tara\ Odo.json "$zhiodo"
+
+    popd
+}
+
 cd "${0%/*}"
 
 echo "Checking for new characters"
@@ -70,6 +90,9 @@ then
     echo "Unable to download all files at this time"
     exit 1
 fi
+
+# Quick hack to fix discrepencies in crew names between SSTApi & Wiki/SSR
+fix_ssr_crew
 
 echo "Starting cachewiki"
 node dist/lib/cachewiki.js

--- a/lib/chars.ts
+++ b/lib/chars.ts
@@ -196,7 +196,7 @@ export async function ssrLookup(name:string, cb:any) {
   var wname=name.replace(/"/gi,"!Q!");
   wname=wname.replace(/,/gi,"!C!");
   try {
-    let data = await fs.readFile(`client/ssr.izausomecreations.com/crew/${wname}.json`, 'utf8');
+    let data = await fs.readFile(`${cfg.dataPath}/ssr.izausomecreations.com/crew/${wname}.json`, 'utf8');
     const obj = JSON.parse(data);
     cb (obj.info ? obj.info : {});
   }

--- a/sttdl.ts
+++ b/sttdl.ts
@@ -34,6 +34,7 @@ async function main() {
   let crew = await STTApi.executeGetRequest('character/get_avatar_crew_archetypes');
   // Post-process the data so that gotcron handle this better
   crew.crew_avatars.forEach((e:any)=>{
+    e.name = e.name.replace(/\u2019/g,"'").replace(/\"/g,"''");
     e.wiki="/wiki/" + e.name.replace(/ /g,'_');
     e.wikiPath = "https://stt.wiki" + e.wiki;
   });


### PR DESCRIPTION
This fix will resolve the mismatch in the crew commands for Zhian'tara Odo and ''Dark Ages'' McCoy.
Also fixes the head image in estats.


Still broken - Emergency Medical Holoprogram Mk.1
- Head image doesn't resolve
- Crew issues if previously added as Emergency Medical Holoprogram Mk. 1

