### PR TITLE
Replace all quotes only if starts with one

### DIFF
--- a/lib/chars.ts
+++ b/lib/chars.ts
@@ -91,7 +91,7 @@ wikidb = obj;
 wikidb.charstars = _.object(wikidb.crewentries.map(x=>x.name), wikidb.crewentries.map(x=>x.stars));
 wikidb.charToCrew = _.groupBy(wikidb.crewentries, x=>x.char);
 
-var traitsSet = new Set();
+var traitsSet = new Set<string>();
 // Add skills as traits
 wikidb.crewentries.forEach(x=>x.traits += ',' + _.uniq(x.skill.map(x=>x.skill)).join(',') );
 // Add vanilla traits

--- a/lib/commands/gcalc.ts
+++ b/lib/commands/gcalc.ts
@@ -29,7 +29,7 @@ module.exports = new Clapp.Command({
         .filter(x => x != undefined && x != '')
         .value();
       let featuredTraits:Array<string> = [];
-      _.forEach(traits, name => {
+      _.forEach(traits, (name:string) => {
         matcher.matchOne(function (err, val) {
           if (err) throw err;
           featuredTraits.push(<string>val);

--- a/sttdl.ts
+++ b/sttdl.ts
@@ -34,7 +34,10 @@ async function main() {
   let crew = await STTApi.executeGetRequest('character/get_avatar_crew_archetypes');
   // Post-process the data so that gotcron handle this better
   crew.crew_avatars.forEach((e:any)=>{
-    e.name = e.name.replace(/\u2019/g,"'").replace(/\"/g,"''");
+    e.name = e.name.replace(/\u2019/g, "'");
+    if (e.name.match(/^\"/)) {
+      e.name = e.name.replace(/\"/g, "''");
+    }
     e.wiki="/wiki/" + e.name.replace(/ /g,'_');
     e.wikiPath = "https://stt.wiki" + e.wiki;
   });

--- a/test/index.ts
+++ b/test/index.ts
@@ -19,7 +19,7 @@ console.log(cfg.dataPath);
 
 describe('gotBot', function () {
 
-  function sendCommand(cmd:string, context?:api.Context) : Promise<string> {
+  function sendCommand(cmd:string, context?:api.Context|any) : Promise<string> {
 
     assert(cli.isCliSentence(cmd));
     if (context == null) {
@@ -455,4 +455,3 @@ describe('missions', function() {
   });
 
 });
-


### PR DESCRIPTION
Issue with wiki needing `"` to be replaced with `''` actually came from some requirements.

If a wiki page starts with a quote `"` the page is not correctly sorted, but if it starts with a single quote `'` the sort does work.

So quotes only need to be replaced if the page starts with one!
[STT Wiki Talk page](https://stt.wiki/wiki/User_talk:Izausome)

Only two characters currently have `"` in their names, and with this patch the results will be as follows.
`Q as "God"` -> `Q as "God"`
`"Dark Ages" McCoy` -> `''Dark Ages'' McCoy`
